### PR TITLE
Add UTF-8 encoding declaration

### DIFF
--- a/reflectme.py
+++ b/reflectme.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from burp import IBurpExtender, ITab, IHttpListener, IScanIssue, IParameter
 from java.awt import Dimension
 from java.awt.event import ActionListener


### PR DESCRIPTION
## Summary
- add a UTF-8 coding declaration to reflectme.py so Python 2.7 can parse UTF-8 literals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2356e3dcc8324a27cc3094b46536c